### PR TITLE
feat(packages): reexport use form hook

### DIFF
--- a/packages/payment-widget/src/ui/button/button.component.tsx
+++ b/packages/payment-widget/src/ui/button/button.component.tsx
@@ -1,14 +1,14 @@
-import type { ButtonProps }  from '@atls-ui-parts/button'
-import type { FC }           from 'react'
+import type { ButtonProps } from '@atls-ui-parts/button'
+import type { FC }          from 'react'
 
-import styled from '@emotion/styled'
-import { useHover }          from 'react-laag'
-import React                 from 'react'
+import styled               from '@emotion/styled'
+import { useHover }         from 'react-laag'
+import React                from 'react'
 
-import { appearanceStyles }  from './button.styles.js'
-import { contentStyles }     from './button.styles.js'
-import { baseStyles }        from './button.styles.js'
-import { shapeStyles }       from './button.styles.js'
+import { appearanceStyles } from './button.styles.js'
+import { contentStyles }    from './button.styles.js'
+import { baseStyles }       from './button.styles.js'
+import { shapeStyles }      from './button.styles.js'
 
 const ButtonElement = (styled.default ?? styled)('button')<ButtonProps>(
   // @ts-expect-error

--- a/packages/payment-widget/src/ui/index.ts
+++ b/packages/payment-widget/src/ui/index.ts
@@ -1,4 +1,5 @@
 export * from './widget.component.js'
 export * from './wrapper/index.js'
+export * from './form/index.js'
 export { Input } from './input/input.component.js'
 export { MemoizedInput } from './input/input.component.js'


### PR DESCRIPTION
- добавил экспорт хука `useForm`. использую его в `drum-in`
- правиль понимаю, что версия пакета сама поднимается, вручную её пробивать не надо?